### PR TITLE
Enable crossterm's `dev-tty` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
+ "filedescriptor",
  "futures-core",
  "libc",
  "mio",
@@ -389,6 +390,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -37,7 +37,7 @@ which = "4.4"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
-crossterm = { version = "0.26", features = ["event-stream"] }
+crossterm = { version = "0.26", features = ["event-stream", "use-dev-tty"] }
 signal-hook = "0.3"
 tokio-stream = "0.1"
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -215,11 +215,6 @@ impl Application {
             }
         } else if stdin().is_tty() || cfg!(feature = "integration") {
             editor.new_file(Action::VerticalSplit);
-        } else if cfg!(target_os = "macos") {
-            // On Linux and Windows, we allow the output of a command to be piped into the new buffer.
-            // This doesn't currently work on macOS because of the following issue:
-            //   https://github.com/crossterm-rs/crossterm/issues/500
-            anyhow::bail!("Piping into helix-term is currently not supported on macOS");
         } else {
             editor
                 .new_file_from_stdin(Action::VerticalSplit)


### PR DESCRIPTION
This fixes piping to Helix on macos.
Also remove the error message preventing this usage.